### PR TITLE
Fixed/added deterministic seed support for Simplex Noise

### DIFF
--- a/online/online.js
+++ b/online/online.js
@@ -144,7 +144,7 @@ function install( PET, auxOnChange ) {
 
 	mainGui.onChange( ()=>{
 
-		seed = noiseSeed();
+		seed = noiseSeed(params.seed);
 		params.height = params.width/2;
 
 		var map = 'map';

--- a/online/simplex-noise.html
+++ b/online/simplex-noise.html
@@ -33,9 +33,14 @@
 		
 		var gui = install( PET );
 		
+		gui.add( params, 'seed' )
+			.min( 0 ).max( 100 ).step( 1 )
+			.name( 'Noise <right>seed</right>' )
+			.$input.classList.add( 'top' );
+
 		gui.add( params, 'scale' )
 			.min( 0 ).max( 100 ).step( 1 )
-			.name( 'Noise <right>scale</right>' )
+			.name( '<right>scale</right>' )
 			.$input.classList.add( 'top' );
 		
 		gui.add( params, 'balance' )

--- a/src/patterns/simplex-noise.js
+++ b/src/patterns/simplex-noise.js
@@ -10,7 +10,7 @@
 
 
 import { Color } from "three";
-import { noise, retexture, mapExp } from "../texture-generator.js";
+import { noise, noiseSeed, retexture, mapExp } from "../texture-generator.js";
 
 
 
@@ -22,6 +22,8 @@ var defaults = {
 
 	scale: 50,
 
+	seed: 50,
+
 	balance: 50,
 
 	color: 0xFFFFFF,
@@ -31,6 +33,8 @@ var defaults = {
 
 
 function pattern( x, y, z, color, options, /*u, v, px, py*/ ) {
+
+	noiseSeed(options.seed);
 
 	var k = 0.5 - 0.5*noise( x, y, z, options.scale );
 
@@ -43,6 +47,7 @@ function pattern( x, y, z, color, options, /*u, v, px, py*/ ) {
 function options( params ) {
 
 	return {
+		seed: params.seed ?? defaults.seed,
 		scale: mapExp( params.scale ?? defaults.scale, 32, 0.5 ),
 		balance: mapExp( params.balance ?? defaults.balance, 0.007, 150 ),
 


### PR DESCRIPTION
In my project I cannot use your newer tsl-textures package, so I am using this one. While using it I noticed that every time I refresh I get a new noise pattern, which is a problem for my project, which I want fully deterministic. As I dug deeper I determined that the pseudo random number generator (PRNG) was not being seeded, or at least not properly.

I've tried to address this using the `esm-seedrandom` package and the ALEA prng algorithm. This is working properly from my local testing.

I've also tried to update the GUI so that the seed can be changed. It does work, but I'm not sure if my modifications match the way that the GUI is managed across all of the other textures.

I hope this is something that you will consider merging. Thanks!

---

On a side note, I have modified this repo as we did the `tel-textures` repo to use Rollup to build to CJS and ES modules and if that's something you'd like to do on this project I'm happy to work on that as well.